### PR TITLE
feat: add validation and correction pipelines

### DIFF
--- a/apps/api/src/core/pipeline/correction_pipeline.py
+++ b/apps/api/src/core/pipeline/correction_pipeline.py
@@ -36,7 +36,7 @@ class CorrectionPipeline:
         """Validate CSV content and apply automatic corrections."""
         try:
             df = pd.read_csv(io.StringIO(csv_content))
-        except (pd.errors.ParserError, ValueError) as e:
+        except Exception as e:
             # Handle malformed CSV content similarly to the validator service
             validation_result = ValidationResult(
                 total_rows=0,

--- a/apps/api/src/core/pipeline/correction_pipeline.py
+++ b/apps/api/src/core/pipeline/correction_pipeline.py
@@ -29,7 +29,12 @@ class CorrectionPipeline:
                 is_valid=False,
                 errors=[{"message": f"Malformed CSV: {str(e)}"}],
                 warnings=[],
-                info=[],
+                total_rows=0,
+                valid_rows=0,
+                error_rows=0,
+                errors=[{"message": f"Malformed CSV: {str(e)}"}],
+                warnings_count=0,
+                processing_time_ms=0,
             )
             return csv_content, {}, validation_result
         validation_result = self.validator.validate(df, marketplace, category)

--- a/apps/api/src/core/pipeline/correction_pipeline.py
+++ b/apps/api/src/core/pipeline/correction_pipeline.py
@@ -24,17 +24,21 @@ class CorrectionPipeline:
             df = pd.read_csv(io.StringIO(csv_content))
         except (pd.errors.ParserError, ValueError) as e:
             # Handle malformed CSV content similarly to the validator service
-            # Here, we return an empty ValidationResult with an error message, but you may want to adjust this
+            from src.schemas.validate import ValidationError as SchemaValidationError
             validation_result = ValidationResult(
-                is_valid=False,
-                errors=[{"message": f"Malformed CSV: {str(e)}"}],
-                warnings=[],
                 total_rows=0,
                 valid_rows=0,
                 error_rows=0,
-                errors=[{"message": f"Malformed CSV: {str(e)}"}],
+                errors=[SchemaValidationError(
+                    row=0,
+                    column="CSV",
+                    error=f"Malformed CSV: {str(e)}",
+                    value=None,
+                    suggestion="Please check CSV format",
+                    severity="error"
+                )],
                 warnings_count=0,
-                processing_time_ms=0,
+                processing_time_ms=0
             )
             return csv_content, {}, validation_result
         validation_result = self.validator.validate(df, marketplace, category)

--- a/apps/api/src/core/pipeline/correction_pipeline.py
+++ b/apps/api/src/core/pipeline/correction_pipeline.py
@@ -1,0 +1,31 @@
+import io
+from typing import Any, Dict, Tuple
+import pandas as pd
+
+from src.schemas.validate import Marketplace, Category, ValidationResult
+from .validation_pipeline import ValidationPipeline
+
+
+class CorrectionPipeline:
+    """Pipeline that runs validation and then applies CSV corrections."""
+
+    def __init__(self, corrector: Any, validator: ValidationPipeline | None = None):
+        self.corrector = corrector
+        self.validator = validator or ValidationPipeline()
+
+    def run(
+        self,
+        csv_content: str,
+        marketplace: Marketplace,
+        category: Category,
+    ) -> Tuple[str, Dict[str, Any], ValidationResult]:
+        """Validate CSV content and apply automatic corrections."""
+        df = pd.read_csv(io.StringIO(csv_content))
+        validation_result = self.validator.validate(df, marketplace, category)
+        corrected_csv, summary = self.corrector.apply_corrections(
+            csv_content=csv_content,
+            validation_result=validation_result,
+            marketplace=marketplace,
+            category=category,
+        )
+        return corrected_csv, summary, validation_result

--- a/apps/api/src/core/pipeline/validation_pipeline.py
+++ b/apps/api/src/core/pipeline/validation_pipeline.py
@@ -51,7 +51,7 @@ class ValidationPipeline:
         provider_cls = MARKETPLACE_PROVIDERS.get(marketplace)
         if provider_cls is None:
             raise ValueError(f"Marketplace '{marketplace.value}' is not registered")
-        provider = provider_cls()
+            raise ValueError(f"Marketplace '{marketplace.value}' is not registered")
 
         self.engine.add_provider(provider)
 

--- a/apps/api/src/core/pipeline/validation_pipeline.py
+++ b/apps/api/src/core/pipeline/validation_pipeline.py
@@ -5,6 +5,7 @@ import pandas as pd
 from src.core.engines.rule_engine import RuleEngine
 from src.core.interfaces import ValidationError as CoreValidationError
 from src.schemas.validate import ValidationResult, ValidationError as SchemaValidationError, Marketplace, Category
+from src.rules.registry import MARKETPLACE_PROVIDERS
 
 
 class ValidationPipeline:
@@ -35,23 +36,12 @@ class ValidationPipeline:
         self.engine.clear_rules()
         self.engine.clear_providers()
 
-        # Load marketplace specific provider
-        if marketplace == Marketplace.MERCADO_LIVRE:
-            from src.rules.marketplaces.mercado_livre import MercadoLivreRuleProvider
-            provider = MercadoLivreRuleProvider()
-        elif marketplace == Marketplace.SHOPEE:
-            from src.rules.marketplaces.shopee import ShopeeRuleProvider
-            provider = ShopeeRuleProvider()
-        elif marketplace == Marketplace.AMAZON:
-            from src.rules.marketplaces.amazon import AmazonRuleProvider
-            provider = AmazonRuleProvider()
-        else:
-            # Raise error for unregistered marketplaces
         # Load marketplace specific provider using registry
         provider_cls = MARKETPLACE_PROVIDERS.get(marketplace)
-        if provider_cls is None:
+        if not provider_cls:
             raise ValueError(f"Marketplace '{marketplace.value}' is not registered")
-            raise ValueError(f"Marketplace '{marketplace.value}' is not registered")
+        
+        provider = provider_cls()
 
         self.engine.add_provider(provider)
 

--- a/apps/api/src/core/pipeline/validation_pipeline.py
+++ b/apps/api/src/core/pipeline/validation_pipeline.py
@@ -47,7 +47,11 @@ class ValidationPipeline:
             provider = AmazonRuleProvider()
         else:
             # Raise error for unregistered marketplaces
+        # Load marketplace specific provider using registry
+        provider_cls = MARKETPLACE_PROVIDERS.get(marketplace)
+        if provider_cls is None:
             raise ValueError(f"Marketplace '{marketplace.value}' is not registered")
+        provider = provider_cls()
 
         self.engine.add_provider(provider)
 

--- a/apps/api/src/core/pipeline/validation_pipeline.py
+++ b/apps/api/src/core/pipeline/validation_pipeline.py
@@ -1,0 +1,75 @@
+import time
+from typing import List
+import pandas as pd
+
+from src.core.engines.rule_engine import RuleEngine
+from src.core.interfaces import ValidationError as CoreValidationError
+from src.schemas.validate import ValidationResult, ValidationError as SchemaValidationError, Marketplace, Category
+
+
+class ValidationPipeline:
+    """Pipeline that coordinates the rule engine validation process."""
+
+    def __init__(self, engine: RuleEngine | None = None):
+        self.engine = engine or RuleEngine()
+
+    def _convert_errors(self, core_errors: List[CoreValidationError]) -> List[SchemaValidationError]:
+        errors: List[SchemaValidationError] = []
+        for error in core_errors:
+            errors.append(
+                SchemaValidationError(
+                    row=error.row,
+                    column=error.column,
+                    error=error.error,
+                    value=str(error.value) if error.value is not None else None,
+                    suggestion=error.suggestion,
+                    severity=error.severity.value,
+                )
+            )
+        return errors
+
+    def validate(self, df: pd.DataFrame, marketplace: Marketplace, category: Category) -> ValidationResult:
+        start_time = time.time()
+
+        # Clear existing rules and providers
+        self.engine.clear_rules()
+        self.engine.clear_providers()
+
+        # Load marketplace specific provider
+        if marketplace == Marketplace.MERCADO_LIVRE:
+            from src.rules.marketplaces.mercado_livre import MercadoLivreRuleProvider
+            provider = MercadoLivreRuleProvider()
+        elif marketplace == Marketplace.SHOPEE:
+            from src.rules.marketplaces.shopee import ShopeeRuleProvider
+            provider = ShopeeRuleProvider()
+        elif marketplace == Marketplace.AMAZON:
+            from src.rules.marketplaces.amazon import AmazonRuleProvider
+            provider = AmazonRuleProvider()
+        else:
+            from src.rules.marketplaces.mercado_livre import MercadoLivreRuleProvider
+            provider = MercadoLivreRuleProvider()
+
+        self.engine.add_provider(provider)
+
+        context = {
+            "marketplace": marketplace.value,
+            "category": category.value,
+        }
+
+        core_errors = self.engine.validate(df, context)
+        schema_errors = self._convert_errors(core_errors)
+
+        total_rows = len(df)
+        error_rows = len({e.row - 1 for e in schema_errors})
+        valid_rows = total_rows - error_rows
+        warnings_count = sum(1 for e in schema_errors if e.severity == "warning")
+        processing_time_ms = int((time.time() - start_time) * 1000)
+
+        return ValidationResult(
+            total_rows=total_rows,
+            valid_rows=valid_rows,
+            error_rows=error_rows,
+            errors=schema_errors,
+            warnings_count=warnings_count,
+            processing_time_ms=processing_time_ms,
+        )

--- a/apps/api/src/core/pipeline/validation_pipeline.py
+++ b/apps/api/src/core/pipeline/validation_pipeline.py
@@ -46,8 +46,8 @@ class ValidationPipeline:
             from src.rules.marketplaces.amazon import AmazonRuleProvider
             provider = AmazonRuleProvider()
         else:
-            from src.rules.marketplaces.mercado_livre import MercadoLivreRuleProvider
-            provider = MercadoLivreRuleProvider()
+            # Raise error for unregistered marketplaces
+            raise ValueError(f"Marketplace '{marketplace.value}' is not registered")
 
         self.engine.add_provider(provider)
 

--- a/apps/api/src/services/corrector_v2.py
+++ b/apps/api/src/services/corrector_v2.py
@@ -1,7 +1,7 @@
 """CSV correction service using the centralized pipeline."""
 import csv
 import io
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Tuple
 import pandas as pd
 from src.schemas.validate import ValidationResult, ValidationError, Marketplace, Category
 from src.core.interfaces.corrector import ICorrection, ICorrectionProvider

--- a/apps/api/src/services/corrector_v2.py
+++ b/apps/api/src/services/corrector_v2.py
@@ -140,7 +140,7 @@ class CSVCorrectorV2:
         csv_content: str,
         marketplace: Marketplace,
         category: Category,
-    ) -> tuple[str, Dict[str, Any], ValidationResult]:
+    ) -> Tuple[str, Dict[str, Any], ValidationResult]:
         """Run full correction pipeline: validate and apply corrections."""
         return self.pipeline.run(csv_content, marketplace, category)
     

--- a/apps/api/src/services/corrector_v2.py
+++ b/apps/api/src/services/corrector_v2.py
@@ -141,7 +141,16 @@ class CSVCorrectorV2:
         marketplace: Marketplace,
         category: Category,
     ) -> Tuple[str, Dict[str, Any], ValidationResult]:
-        """Run full correction pipeline: validate and apply corrections."""
+        """
+        Run full correction pipeline: validate and apply corrections.
+        
+        Returns:
+            Tuple[str, Dict[str, Any], ValidationResult]: 
+                A tuple containing:
+                    - corrected_csv_content (str): The corrected CSV as a string
+                    - correction_summary (Dict[str, Any]): A summary of the corrections applied
+                    - validation_result (ValidationResult): The validation result after corrections
+        """
         return self.pipeline.run(csv_content, marketplace, category)
     
     def apply_corrections(

--- a/apps/api/src/services/corrector_v2.py
+++ b/apps/api/src/services/corrector_v2.py
@@ -1,6 +1,4 @@
-"""
-CSV Correction Service V2 - Using Plugin Architecture
-"""
+"""CSV correction service using the centralized pipeline."""
 import csv
 import io
 from typing import Dict, List, Any, Optional
@@ -14,6 +12,7 @@ from src.core.corrections.base import (
     NumericCleanCorrection,
 )
 from src.core.corrections.base import AutoGenerateCorrection
+from src.core.pipeline.correction_pipeline import CorrectionPipeline
 
 
 class MarketplaceCorrectionProvider(ICorrectionProvider):
@@ -130,10 +129,20 @@ class MarketplaceCorrectionProvider(ICorrectionProvider):
 
 
 class CSVCorrectorV2:
-    """New CSV Corrector using plugin architecture"""
-    
+    """New CSV Corrector using plugin architecture and pipeline."""
+
     def __init__(self):
-        pass
+        # Initialize pipeline with this corrector instance
+        self.pipeline = CorrectionPipeline(corrector=self)
+
+    def correct_csv(
+        self,
+        csv_content: str,
+        marketplace: Marketplace,
+        category: Category,
+    ) -> tuple[str, Dict[str, Any], ValidationResult]:
+        """Run full correction pipeline: validate and apply corrections."""
+        return self.pipeline.run(csv_content, marketplace, category)
     
     def apply_corrections(
         self, 

--- a/apps/api/src/services/validator.py
+++ b/apps/api/src/services/validator.py
@@ -1,21 +1,11 @@
-"""
-Validator V2 - Using Plugin Architecture
-Adapter to integrate new architecture with existing code
-"""
-import pandas as pd
+"""CSV validation service using the centralized pipeline."""
 import io
 from typing import List, Dict, Any
 from fastapi import UploadFile
-import time
+import pandas as pd
 
-from src.schemas.validate import (
-    ValidationError as SchemaValidationError,
-    ValidationResult,
-    Marketplace,
-    Category,
-)
-from src.core.engines.rule_engine import RuleEngine
-from src.core.interfaces import ValidationError as CoreValidationError
+from src.schemas.validate import ValidationResult, Marketplace, Category
+from src.core.pipeline.validation_pipeline import ValidationPipeline
 
 
 class CSVValidator:
@@ -25,7 +15,7 @@ class CSVValidator:
     """
     
     def __init__(self):
-        self.engine = RuleEngine()
+        self.pipeline = ValidationPipeline()
     
     async def validate_csv(
         self,
@@ -44,94 +34,25 @@ class CSVValidator:
         Returns:
             ValidationResult with all errors found
         """
-        start_time = time.time()
-        
         # Read CSV content
         content = await file.read()
-        csv_string = content.decode('utf-8')
-        
+        csv_string = content.decode("utf-8")
+
         # Parse CSV into DataFrame
         try:
             df = pd.read_csv(io.StringIO(csv_string))
-        except Exception as e:
-            # Return error if CSV is malformed
+        except Exception:
             return ValidationResult(
                 total_rows=0,
                 valid_rows=0,
                 error_rows=0,
                 errors=[],
                 warnings_count=0,
-                processing_time_ms=int((time.time() - start_time) * 1000)
+                processing_time_ms=0,
             )
-        
-        # Clear any existing rules
-        self.engine.clear_rules()
-        self.engine.clear_providers()
-        
-        # Load marketplace-specific rules
-        if marketplace == Marketplace.MERCADO_LIVRE:
-            from src.rules.marketplaces.mercado_livre import MercadoLivreRuleProvider
-            provider = MercadoLivreRuleProvider()
-            self.engine.add_provider(provider)
-        elif marketplace == Marketplace.SHOPEE:
-            from src.rules.marketplaces.shopee import ShopeeRuleProvider
-            provider = ShopeeRuleProvider()
-            self.engine.add_provider(provider)
-        elif marketplace == Marketplace.AMAZON:
-            from src.rules.marketplaces.amazon import AmazonRuleProvider
-            provider = AmazonRuleProvider()
-            self.engine.add_provider(provider)
-        else:
-            # For marketplaces not yet implemented, use Mercado Livre as default
-            from src.rules.marketplaces.mercado_livre import MercadoLivreRuleProvider
-            provider = MercadoLivreRuleProvider()
-            self.engine.add_provider(provider)
-        
-        # Create context for validation
-        context = {
-            'marketplace': marketplace.value,
-            'category': category.value
-        }
-        
-        # Run validation
-        core_errors = self.engine.validate(df, context)
-        
-        # Convert core errors to schema errors
-        schema_errors = self._convert_errors(core_errors)
-        
-        # Calculate statistics
-        total_rows = len(df)
-        error_rows = len(set(e.row - 1 for e in schema_errors))  # Unique rows with errors
-        valid_rows = total_rows - error_rows
-        warnings_count = sum(1 for e in schema_errors if e.severity == "warning")
-        
-        processing_time_ms = int((time.time() - start_time) * 1000)
-        
-        return ValidationResult(
-            total_rows=total_rows,
-            valid_rows=valid_rows,
-            error_rows=error_rows,
-            errors=schema_errors,
-            warnings_count=warnings_count,
-            processing_time_ms=processing_time_ms
-        )
-    
-    def _convert_errors(self, core_errors: List[CoreValidationError]) -> List[SchemaValidationError]:
-        """Convert core ValidationError to schema ValidationError"""
-        schema_errors = []
-        
-        for error in core_errors:
-            schema_error = SchemaValidationError(
-                row=error.row,
-                column=error.column,
-                error=error.error,
-                value=str(error.value) if error.value is not None else None,
-                suggestion=error.suggestion,
-                severity=error.severity.value  # Convert enum to string
-            )
-            schema_errors.append(schema_error)
-        
-        return schema_errors
+
+        # Delegate validation to the pipeline
+        return self.pipeline.validate(df, marketplace, category)
 
 
 # Create singleton instance for backward compatibility

--- a/apps/api/tests/test_pipelines.py
+++ b/apps/api/tests/test_pipelines.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+from src.core.pipeline.validation_pipeline import ValidationPipeline
+from src.schemas.validate import Marketplace, Category
+from src.services.corrector_v2 import CSVCorrectorV2
+
+
+def test_validation_pipeline_detects_errors():
+    df = pd.DataFrame({
+        'sku': ['SKU1', 'SKU2'],
+        'title': ['Valid title', 'Invalid title that is way too long for marketplace'],
+        'price': [10.0, -5.0],
+        'available_quantity': [5, 5],
+        'condition': ['new', 'new']
+    })
+    pipeline = ValidationPipeline()
+    result = pipeline.validate(df, Marketplace.MERCADO_LIVRE, Category.ELETRONICOS)
+    assert result.error_rows > 0
+    assert any(e.column == 'price' for e in result.errors)
+
+
+def test_correction_pipeline_applies_corrections():
+    csv_content = (
+        "sku,title,price,stock,condition\n"
+        ",This is a very long title that exceeds the maximum allowed length for Mercado Livre marketplace,-10,-5,\n"
+    )
+    corrector = CSVCorrectorV2()
+    corrected_csv, summary, result = corrector.correct_csv(
+        csv_content=csv_content,
+        marketplace=Marketplace.MERCADO_LIVRE,
+        category=Category.ELETRONICOS,
+    )
+    assert summary["total_corrections"] > 0
+    assert result.error_rows > 0
+    assert corrected_csv != csv_content


### PR DESCRIPTION
## Summary
- add centralized ValidationPipeline and CorrectionPipeline
- refactor CSV validator and corrector services to use pipelines
- test validation and correction pipelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3701f81c832a9d81bbce3e3176c2