### PR TITLE
feat: add marketplace provider registry

### DIFF
--- a/apps/api/src/rules/registry.py
+++ b/apps/api/src/rules/registry.py
@@ -1,0 +1,15 @@
+from typing import Dict, Type
+
+from src.schemas.validate import Marketplace
+from src.core.interfaces import IRuleProvider
+
+from src.rules.marketplaces.mercado_livre.provider import MercadoLivreRuleProvider
+from src.rules.marketplaces.shopee.provider import ShopeeRuleProvider
+from src.rules.marketplaces.amazon.provider import AmazonRuleProvider
+
+# Mapping between marketplaces and their corresponding rule provider classes
+MARKETPLACE_PROVIDERS: Dict[Marketplace, Type[IRuleProvider]] = {
+    Marketplace.MERCADO_LIVRE: MercadoLivreRuleProvider,
+    Marketplace.SHOPEE: ShopeeRuleProvider,
+    Marketplace.AMAZON: AmazonRuleProvider,
+}


### PR DESCRIPTION
## Summary
- add registry mapping marketplaces to rule providers
- use registry in CSVValidator and raise error for unknown marketplace
- expand validation tests for provider lookup and unregistered marketplace error

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d36fe4338832aaa22fb097cc3ccc2