### PR TITLE
test(golden): add pytest integration [4/6]

### DIFF
--- a/tests/golden/conftest.py
+++ b/tests/golden/conftest.py
@@ -1,0 +1,88 @@
+"""Pytest configuration for golden tests."""
+
+import pytest
+from pathlib import Path
+from typing import List
+import tempfile
+import shutil
+
+from tests.golden.golden_runner import run_golden_case, discover_cases, load_spec
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line("markers", "golden: mark test as golden test")
+    config.addinivalue_line("markers", "mercado_livre: mark test for Mercado Livre")
+    config.addinivalue_line("markers", "shopee: mark test for Shopee")
+    config.addinivalue_line("markers", "amazon: mark test for Amazon")
+
+
+@pytest.fixture
+def golden_case():
+    """Fixture for running a golden test case."""
+    def _run_case(case_dir: str, **kwargs):
+        return run_golden_case(case_dir, **kwargs)
+    return _run_case
+
+
+@pytest.fixture
+def pipeline_ctx():
+    """Fixture providing pipeline context."""
+    return {
+        'marketplace': None,
+        'category': None,
+        'config': {},
+    }
+
+
+@pytest.fixture
+def tmp_outdir():
+    """Fixture providing temporary output directory."""
+    tmpdir = tempfile.mkdtemp(prefix="golden_test_")
+    yield tmpdir
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def pytest_collection_modifyitems(items):
+    """Auto-mark tests based on their path."""
+    for item in items:
+        # Get the test file path
+        test_path = str(item.fspath)
+        
+        # Auto-add golden marker if in golden directory
+        if 'tests/golden' in test_path:
+            item.add_marker(pytest.mark.golden)
+        
+        # Auto-add marketplace markers based on path
+        if 'mercado_livre' in test_path:
+            item.add_marker(pytest.mark.mercado_livre)
+        elif 'shopee' in test_path:
+            item.add_marker(pytest.mark.shopee)
+        elif 'amazon' in test_path:
+            item.add_marker(pytest.mark.amazon)
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize tests with discovered golden cases."""
+    if "case_dir" in metafunc.fixturenames:
+        # Check if specific marketplace filter is requested
+        markers = [m.name for m in metafunc.definition.iter_markers()]
+        
+        # Discover all cases
+        all_cases = discover_cases()
+        
+        # Filter by marketplace if marker present
+        filtered_cases = []
+        for case in all_cases:
+            if 'mercado_livre' in markers and 'mercado_livre' not in case:
+                continue
+            if 'shopee' in markers and 'shopee' not in case:
+                continue
+            if 'amazon' in markers and 'amazon' not in case:
+                continue
+            filtered_cases.append(case)
+        
+        if filtered_cases:
+            # Use case name as test ID
+            ids = [Path(case).name for case in filtered_cases]
+            metafunc.parametrize("case_dir", filtered_cases, ids=ids)

--- a/tests/golden/test_golden.py
+++ b/tests/golden/test_golden.py
@@ -1,0 +1,38 @@
+"""Golden tests for ValidaHub pipeline."""
+
+import pytest
+from pathlib import Path
+
+from tests.golden.golden_runner import run_golden_case, load_spec
+
+
+@pytest.mark.golden
+def test_golden_auto_discovery(case_dir):
+    """Test all discovered golden cases."""
+    spec = load_spec(Path(case_dir) / "config.yaml")
+    result = run_golden_case(case_dir, spec=spec)
+    assert result.passed, result.diff_summary
+
+
+@pytest.mark.golden
+@pytest.mark.mercado_livre
+class TestMercadoLivre:
+    """Golden tests specific to Mercado Livre."""
+    
+    def test_eletronicos_basic(self, golden_case):
+        """Test basic electronics category validation."""
+        case_dir = "tests/golden/mercado_livre/eletronicos/case_001"
+        result = golden_case(case_dir)
+        assert result.passed, result.diff_summary
+
+
+@pytest.mark.golden
+@pytest.mark.shopee
+class TestShopee:
+    """Golden tests specific to Shopee."""
+    
+    def test_moda_basic(self, golden_case):
+        """Test basic fashion category validation."""
+        case_dir = "tests/golden/shopee/moda/case_001"
+        result = golden_case(case_dir)
+        assert result.passed, result.diff_summary


### PR DESCRIPTION
## Part 4 of 6: Pytest Integration

### Scope
Pytest configuration, fixtures, and test discovery

### Changes
- **conftest.py**: Pytest configuration with fixtures and markers
- **test_golden.py**: Test definitions and marketplace-specific classes

### Files (126 LOC)
- `tests/golden/conftest.py` (93 LOC)
- `tests/golden/test_golden.py` (33 LOC)

### Stack
This is PR #4 of a 6-part stack:
1. ✅ CI Infrastructure ([#10](https://github.com/drapala/validahub-new/pull/10) - merged)
2. ✅ Core Framework ([#11](https://github.com/drapala/validahub-new/pull/11) - merged)
3. ✅ Golden Runner ([#12](https://github.com/drapala/validahub-new/pull/12) - merged)
4. **→ Pytest Integration** (this PR)
5. Test Cases
6. Documentation

### Key Features
- Custom markers: `@pytest.mark.golden`, `@pytest.mark.mercado_livre`, etc.
- Auto-discovery of test cases from directory structure
- Parametrization based on discovered cases
- Fixtures: `golden_case`, `pipeline_ctx`, `tmp_outdir`
- Automatic marker assignment based on path

### Test Organization
```python
@pytest.mark.golden  # Auto-discovered tests
@pytest.mark.mercado_livre  # Marketplace-specific
class TestMercadoLivre  # Organized test classes
```

### Commands Enabled
```bash
pytest -m golden  # All golden tests
pytest -m "golden and mercado_livre"  # Specific marketplace
pytest tests/golden/test_golden.py::test_golden_auto_discovery[case_001]  # Specific case
```

### Test Plan
- [ ] Fixtures load correctly
- [ ] Auto-discovery finds test cases
- [ ] Markers filter tests properly
- [ ] Integration with runner works

### Dependencies
- Requires PR #3 (merged) for runner
- Required by PR #5 (test cases)

### Rollback
Remove pytest configuration files