### PR TITLE
chore: include aiofiles dependency

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -24,6 +24,7 @@ passlib = {extras = ["bcrypt"], version = "^1.7.4"}
 pandas = "^2.2.2"
 openpyxl = "^3.1.5"
 pyyaml = "^6.0.1"
+aiofiles = "^23.2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -18,6 +18,7 @@ pandas==2.2.0
 openpyxl==3.1.2
 xlsxwriter==3.2.0
 reportlab==4.2.5
+aiofiles==23.2.1
 
 # Dev dependencies
 pytest==7.4.4


### PR DESCRIPTION
## Summary
- add aiofiles runtime dependency
- expose aiofiles in poetry config

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config_adapter')*


------
https://chatgpt.com/codex/tasks/task_e_68ac80a4db98832ab81d78b1279869b6