### PR TITLE
refactor: inject rule engine via interface

### DIFF
--- a/apps/api/src/core/interfaces/__init__.py
+++ b/apps/api/src/core/interfaces/__init__.py
@@ -20,6 +20,7 @@ from .corrector import (
     ICorrectionStrategy,
     ICorrectionProvider
 )
+from .rule_engine import IRuleEngineService
 
 __all__ = [
     # Rule interfaces
@@ -37,4 +38,6 @@ __all__ = [
     'ICorrection',
     'ICorrectionStrategy',
     'ICorrectionProvider',
+    # Rule engine service
+    'IRuleEngineService',
 ]

--- a/apps/api/src/core/interfaces/rule_engine.py
+++ b/apps/api/src/core/interfaces/rule_engine.py
@@ -1,0 +1,29 @@
+"""Interfaces for rule engine service."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Tuple
+
+from schemas.validate import ValidationItem
+
+
+class IRuleEngineService(ABC):
+    """Abstract interface for rule engine service."""
+
+    @abstractmethod
+    async def validate_row(
+        self,
+        row: Dict[str, Any],
+        marketplace: str,
+        row_number: int = 0,
+    ) -> List[ValidationItem]:
+        """Validate a single row of data."""
+
+    @abstractmethod
+    async def validate_and_fix_row(
+        self,
+        row: Dict[str, Any],
+        marketplace: str,
+        row_number: int = 0,
+        auto_fix: bool = True,
+    ) -> Tuple[Dict[str, Any], List[ValidationItem]]:
+        """Validate and optionally fix a row."""

--- a/apps/api/src/core/use_cases/correct_csv.py
+++ b/apps/api/src/core/use_cases/correct_csv.py
@@ -6,18 +6,16 @@ Handles domain logic for automatic CSV corrections.
 import io
 import uuid
 from core.logging_config import get_logger
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 from dataclasses import dataclass
 import pandas as pd
 
 from .base import UseCase
 from ..pipeline.validation_pipeline_decoupled import ValidationPipelineDecoupled
 from utils import DataFrameUtils
-from ...infrastructure.validators.rule_engine_validator import RuleEngineValidator
-from ...services.rule_engine_service import RuleEngineService
 from ...schemas.validate import (
+    Category,
     Marketplace,
-    Category
 )
 
 logger = get_logger(__name__)
@@ -29,7 +27,7 @@ class CorrectCsvInput:
     csv_content: str
     marketplace: Marketplace
     category: Category
-    options: Dict[str, Any] = None
+    options: Optional[Dict[str, Any]] = None
     original_filename: str = "file.csv"
     
     def __post_init__(self):
@@ -57,24 +55,8 @@ class CorrectCsvUseCase(UseCase[CorrectCsvInput, CorrectCsvOutput]):
     without any knowledge of HTTP, file I/O, or other infrastructure concerns.
     """
     
-    def __init__(
-        self,
-        validation_pipeline: ValidationPipelineDecoupled = None,
-        rule_engine_service: Optional[RuleEngineService] = None
-    ):
-        """
-        Initialize the use case with optional dependencies.
-        
-        Args:
-            validation_pipeline: Optional custom validation pipeline
-            rule_engine_service: Optional RuleEngineService for dependency injection
-        """
-        if validation_pipeline is None:
-            # Use injected RuleEngineService or create default if not provided
-            if rule_engine_service is None:
-                rule_engine_service = RuleEngineService()
-            validator = RuleEngineValidator(rule_engine_service)
-            validation_pipeline = ValidationPipelineDecoupled(validator)
+    def __init__(self, validation_pipeline: ValidationPipelineDecoupled):
+        """Initialize the use case with required validation pipeline."""
         self.validation_pipeline = validation_pipeline
     
     async def execute(self, input_data: CorrectCsvInput) -> CorrectCsvOutput:

--- a/apps/api/src/core/use_cases/validate_csv.py
+++ b/apps/api/src/core/use_cases/validate_csv.py
@@ -4,22 +4,19 @@ Handles domain logic without I/O concerns.
 """
 
 import io
-import time
 import uuid
 from core.logging_config import get_logger
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 from dataclasses import dataclass
 import pandas as pd
 
 from .base import UseCase
 from ..pipeline.validation_pipeline_decoupled import ValidationPipelineDecoupled
 from utils import DataFrameUtils
-from ...infrastructure.validators.rule_engine_validator import RuleEngineValidator
-from ...services.rule_engine_service import RuleEngineService
 from ...schemas.validate import (
-    ValidationResult,
     Marketplace,
-    Category
+    Category,
+    ValidationResult,
 )
 
 logger = get_logger(__name__)
@@ -32,7 +29,7 @@ class ValidateCsvInput:
     marketplace: Marketplace
     category: Category
     auto_fix: bool = True
-    options: Dict[str, Any] = None
+    options: Optional[Dict[str, Any]] = None
     job_id: Optional[str] = None
     
     def __post_init__(self):
@@ -50,24 +47,8 @@ class ValidateCsvUseCase(UseCase[ValidateCsvInput, ValidationResult]):
     without any knowledge of HTTP, file I/O, or other infrastructure concerns.
     """
     
-    def __init__(
-        self, 
-        validation_pipeline: ValidationPipelineDecoupled = None,
-        rule_engine_service: Optional[RuleEngineService] = None
-    ):
-        """
-        Initialize the use case with optional dependencies.
-        
-        Args:
-            validation_pipeline: Optional custom validation pipeline
-            rule_engine_service: Optional RuleEngineService for dependency injection
-        """
-        if validation_pipeline is None:
-            # Use injected RuleEngineService or create default if not provided
-            if rule_engine_service is None:
-                rule_engine_service = RuleEngineService()
-            validator = RuleEngineValidator(rule_engine_service)
-            validation_pipeline = ValidationPipelineDecoupled(validator)
+    def __init__(self, validation_pipeline: ValidationPipelineDecoupled):
+        """Initialize the use case with required validation pipeline."""
         self.validation_pipeline = validation_pipeline
     
     async def execute(self, input_data: ValidateCsvInput) -> ValidationResult:

--- a/apps/api/src/core/use_cases/validate_row.py
+++ b/apps/api/src/core/use_cases/validate_row.py
@@ -4,18 +4,16 @@ Handles domain logic for row-level validation.
 """
 
 from core.logging_config import get_logger
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass
 
 from .base import UseCase
 from ..pipeline.validation_pipeline_decoupled import ValidationPipelineDecoupled
-from ...infrastructure.validators.rule_engine_validator import RuleEngineValidator
-from ...services.rule_engine_service import RuleEngineService
 from ...schemas.validate import (
+    Category,
+    Marketplace,
     ValidationItem,
     ValidationStatus,
-    Marketplace,
-    Category
 )
 
 logger = get_logger(__name__)
@@ -50,24 +48,8 @@ class ValidateRowUseCase(UseCase[ValidateRowInput, ValidateRowOutput]):
     without any knowledge of HTTP or other infrastructure concerns.
     """
     
-    def __init__(
-        self,
-        validation_pipeline: ValidationPipelineDecoupled = None,
-        rule_engine_service: Optional[RuleEngineService] = None
-    ):
-        """
-        Initialize the use case with optional dependencies.
-        
-        Args:
-            validation_pipeline: Optional custom validation pipeline
-            rule_engine_service: Optional RuleEngineService for dependency injection
-        """
-        if validation_pipeline is None:
-            # Use injected RuleEngineService or create default if not provided
-            if rule_engine_service is None:
-                rule_engine_service = RuleEngineService()
-            validator = RuleEngineValidator(rule_engine_service)
-            validation_pipeline = ValidationPipelineDecoupled(validator)
+    def __init__(self, validation_pipeline: ValidationPipelineDecoupled):
+        """Initialize the use case with required validation pipeline."""
         self.validation_pipeline = validation_pipeline
     
     async def execute(self, input_data: ValidateRowInput) -> ValidateRowOutput:

--- a/apps/api/src/infrastructure/validators/rule_engine_validator.py
+++ b/apps/api/src/infrastructure/validators/rule_engine_validator.py
@@ -7,12 +7,11 @@ import asyncio
 import copy
 import functools
 from core.logging_config import get_logger
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-from core.interfaces.validation import IValidator
 from core.interfaces.rule_engine import IRuleEngineService
+from core.interfaces.validation import IValidator
 from schemas.validate import ValidationItem
-from services.rule_engine_service import RuleEngineService
 
 logger = get_logger(__name__)
 
@@ -23,19 +22,9 @@ class RuleEngineValidator(IValidator):
     This allows the existing rule engine to work with the new pipeline.
     """
     
-    def __init__(self, rule_engine_service: Optional[IRuleEngineService] = None):
-        """
-        Initialize validator with rule engine service.
-        
-        Args:
-            rule_engine_service: The rule engine service to use
-        """
-        # Can accept either the interface or concrete implementation
-        if rule_engine_service is None:
-            # Fallback to concrete implementation for backward compatibility
-            self.rule_engine_service = RuleEngineService()
-        else:
-            self.rule_engine_service = rule_engine_service
+    def __init__(self, rule_engine_service: IRuleEngineService):
+        """Initialize validator with rule engine service."""
+        self.rule_engine_service = rule_engine_service
     
     async def validate_row(
         self,

--- a/apps/api/tests/unit/test_rule_engine_validator.py
+++ b/apps/api/tests/unit/test_rule_engine_validator.py
@@ -1,0 +1,30 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from src.core.interfaces import IRuleEngineService
+from src.infrastructure.validators.rule_engine_validator import RuleEngineValidator
+
+
+@pytest.mark.asyncio
+async def test_validate_row_uses_service():
+    service = AsyncMock(spec=IRuleEngineService)
+    service.validate_row.return_value = ["item"]
+    validator = RuleEngineValidator(service)
+
+    result = await validator.validate_row({}, "ml")
+
+    assert result == ["item"]
+    service.validate_row.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_validate_and_fix_row_uses_service():
+    service = AsyncMock(spec=IRuleEngineService)
+    service.validate_and_fix_row.return_value = ({}, ["item"])
+    validator = RuleEngineValidator(service)
+
+    fixed_row, items = await validator.validate_and_fix_row({}, "ml")
+
+    assert fixed_row == {}
+    assert items == ["item"]
+    service.validate_and_fix_row.assert_awaited_once()


### PR DESCRIPTION
## Summary
- require `IRuleEngineService` in `RuleEngineValidator`
- provide rule engine service through FastAPI dependency functions
- add tests using `IRuleEngineService` mocks

## Testing
- `pre-commit run --files apps/api/src/infrastructure/validators/rule_engine_validator.py apps/api/src/core/interfaces/rule_engine.py apps/api/src/core/interfaces/__init__.py apps/api/src/core/use_cases/validate_csv.py apps/api/src/core/use_cases/correct_csv.py apps/api/src/core/use_cases/validate_row.py apps/api/src/api/v1/validation_refactored.py apps/api/tests/unit/test_rule_engine_validator.py` *(fails: InvalidConfigError)*
- `pytest apps/api/tests/unit/test_rule_engine_validator.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68ace70f8c8c832ab2780fc174ea67f0